### PR TITLE
Pop growth rebalanced

### DIFF
--- a/acquistion_of_technology/common/buildings/z_aot_phanon_buildings.txt
+++ b/acquistion_of_technology/common/buildings/z_aot_phanon_buildings.txt
@@ -2113,8 +2113,8 @@ building_phanon_clone_vats = {
 		building_stellarite_clone_vats
 	}
 	planet_modifier = {
-		pop_growth_speed = 4
-		planet_pop_assembly_organic_add = 16
+		pop_growth_speed = 3
+		planet_pop_assembly_organic_add = 8
 	}
 	resources = {
 		category = planet_buildings

--- a/acquistion_of_technology/common/buildings/z_aot_phanon_buildings.txt
+++ b/acquistion_of_technology/common/buildings/z_aot_phanon_buildings.txt
@@ -2114,7 +2114,7 @@ building_phanon_clone_vats = {
 	}
 	planet_modifier = {
 		pop_growth_speed = 3
-		planet_pop_assembly_organic_add = 8
+		planet_pop_assembly_organic_add = 10
 	}
 	resources = {
 		category = planet_buildings

--- a/acquistion_of_technology/common/buildings/z_aot_stellarite_buildings.txt
+++ b/acquistion_of_technology/common/buildings/z_aot_stellarite_buildings.txt
@@ -1969,8 +1969,8 @@ building_stellarite_clone_vats = {
 		}
 	}
 	planet_modifier = {
-		pop_growth_speed = 8
-		planet_pop_assembly_organic_add = 32
+		pop_growth_speed = 4
+		planet_pop_assembly_organic_add = 16
 	}
 	resources = {
 		category = planet_buildings

--- a/acquistion_of_technology/common/buildings/z_aot_stellarite_buildings.txt
+++ b/acquistion_of_technology/common/buildings/z_aot_stellarite_buildings.txt
@@ -1970,7 +1970,7 @@ building_stellarite_clone_vats = {
 	}
 	planet_modifier = {
 		pop_growth_speed = 4
-		planet_pop_assembly_organic_add = 16
+		planet_pop_assembly_organic_add = 20
 	}
 	resources = {
 		category = planet_buildings

--- a/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
+++ b/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
@@ -2121,7 +2121,7 @@ phanon_roboman = {
 			}
 			can_assemble_cyborg_pop = yes
 		}
-		planet_pop_assembly_organic_add = 15
+		planet_pop_assembly_organic_add = 12.5
 	}
 	resources = {
 		category = planet_pop_assemblers
@@ -4536,7 +4536,7 @@ stellarite_roboman = {
 			}
 			can_assemble_cyborg_pop = yes
 		}
-		planet_pop_assembly_organic_add = 18.5
+		planet_pop_assembly_organic_add = 15.5
 	}
 	resources = {
 		category = planet_pop_assemblers

--- a/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
+++ b/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
@@ -1955,7 +1955,7 @@ phanon_apothecary = {
 	possible_precalc = can_fill_specialist_job
 	planet_modifier = {
 		planet_amenities_add = 30
-		planet_pop_assembly_organic_mult = 0.75
+		planet_pop_assembly_organic_mult = 0.4
 		pop_environment_tolerance = 0.4
 		pop_growth_speed = 1.5
 	}
@@ -2027,7 +2027,7 @@ phanon_broodmother = {
 	possible_precalc = can_fill_drone_job
 	planet_modifier = {
 		planet_amenities_no_happiness_add = 15
-		planet_pop_assembly_organic_mult = 1.5
+		planet_pop_assembly_organic_mult = 0.75
 		pop_environment_tolerance = 0.4
 		pop_growth_speed = 3
 	}
@@ -4370,7 +4370,7 @@ stellarite_apothecary = {
 	possible_precalc = can_fill_specialist_job
 	planet_modifier = {
 		planet_amenities_add = 60
-		planet_pop_assembly_organic_mult = 1.5
+		planet_pop_assembly_organic_mult = 0.75
 		pop_environment_tolerance = 0.8
 		pop_growth_speed = 3
 	}
@@ -4442,7 +4442,7 @@ stellarite_broodmother = {
 	possible_precalc = can_fill_drone_job
 	planet_modifier = {
 		planet_amenities_no_happiness_add = 30
-		planet_pop_assembly_organic_mult = 3
+		planet_pop_assembly_organic_mult = 1.5
 		pop_environment_tolerance = 0.8
 		pop_growth_speed = 6
 	}

--- a/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
+++ b/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
@@ -2111,7 +2111,7 @@ phanon_roboman = {
 				}
 			}
 		}
-		planet_pop_assembly_add = 30
+		planet_pop_assembly_add = 12.5
 	}
 	triggered_planet_modifier = {
 		potential = {
@@ -2121,7 +2121,7 @@ phanon_roboman = {
 			}
 			can_assemble_cyborg_pop = yes
 		}
-		planet_pop_assembly_organic_add = 32
+		planet_pop_assembly_organic_add = 15
 	}
 	resources = {
 		category = planet_pop_assemblers
@@ -4526,7 +4526,7 @@ stellarite_roboman = {
 				}
 			}
 		}
-		planet_pop_assembly_add = 60
+		planet_pop_assembly_add = 15.5
 	}
 	triggered_planet_modifier = {
 		potential = {
@@ -4536,7 +4536,7 @@ stellarite_roboman = {
 			}
 			can_assemble_cyborg_pop = yes
 		}
-		planet_pop_assembly_organic_add = 64
+		planet_pop_assembly_organic_add = 18.5
 	}
 	resources = {
 		category = planet_pop_assemblers

--- a/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
+++ b/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
@@ -1955,7 +1955,7 @@ phanon_apothecary = {
 	possible_precalc = can_fill_specialist_job
 	planet_modifier = {
 		planet_amenities_add = 30
-		planet_pop_assembly_organic_mult = 1.5
+		planet_pop_assembly_organic_mult = 0.75
 		pop_environment_tolerance = 0.4
 		pop_growth_speed = 1.5
 	}
@@ -2027,7 +2027,7 @@ phanon_broodmother = {
 	possible_precalc = can_fill_drone_job
 	planet_modifier = {
 		planet_amenities_no_happiness_add = 15
-		planet_pop_assembly_organic_mult = 3
+		planet_pop_assembly_organic_mult = 1.5
 		pop_environment_tolerance = 0.4
 		pop_growth_speed = 3
 	}
@@ -2183,7 +2183,7 @@ phanon_robodrone = {
 	}
 	possible_precalc = can_fill_drone_job
 	planet_modifier = {
-		planet_pop_assembly_add = 30
+		planet_pop_assembly_add = 12.5
 		planet_amenities_no_happiness_add = 30
 	}
 	resources = {
@@ -4370,7 +4370,7 @@ stellarite_apothecary = {
 	possible_precalc = can_fill_specialist_job
 	planet_modifier = {
 		planet_amenities_add = 60
-		planet_pop_assembly_organic_mult = 3
+		planet_pop_assembly_organic_mult = 1.5
 		pop_environment_tolerance = 0.8
 		pop_growth_speed = 3
 	}
@@ -4442,7 +4442,7 @@ stellarite_broodmother = {
 	possible_precalc = can_fill_drone_job
 	planet_modifier = {
 		planet_amenities_no_happiness_add = 30
-		planet_pop_assembly_organic_mult = 6
+		planet_pop_assembly_organic_mult = 3
 		pop_environment_tolerance = 0.8
 		pop_growth_speed = 6
 	}
@@ -4598,7 +4598,7 @@ stellarite_robodrone = {
 	}
 	possible_precalc = can_fill_drone_job
 	planet_modifier = {
-		planet_pop_assembly_add = 60
+		planet_pop_assembly_add = 15.5
 		planet_amenities_no_happiness_add = 60
 	}
 	resources = {

--- a/acquistion_of_technology/common/technology/z_aot_phanon_building_tech.txt
+++ b/acquistion_of_technology/common/technology/z_aot_phanon_building_tech.txt
@@ -589,7 +589,7 @@ tech_phanon_clone_vats = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.2
+		pop_growth_speed = 0.25
 	}
 	potential = {
 		has_tradition = tr_genetics_finish
@@ -645,7 +645,7 @@ tech_phanon_psi_altar = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.2
+		pop_growth_speed = 0.25
 	}
 	potential = {
 		has_tradition = tr_psionics_finish

--- a/acquistion_of_technology/common/technology/z_aot_phanon_building_tech.txt
+++ b/acquistion_of_technology/common/technology/z_aot_phanon_building_tech.txt
@@ -589,7 +589,7 @@ tech_phanon_clone_vats = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.8
+		pop_growth_speed = 0.2
 	}
 	potential = {
 		has_tradition = tr_genetics_finish
@@ -645,7 +645,7 @@ tech_phanon_psi_altar = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.8
+		pop_growth_speed = 0.2
 	}
 	potential = {
 		has_tradition = tr_psionics_finish

--- a/acquistion_of_technology/common/technology/z_aot_stellarite_building_tech.txt
+++ b/acquistion_of_technology/common/technology/z_aot_stellarite_building_tech.txt
@@ -446,7 +446,7 @@ tech_stellarite_clone_vats = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.3
+		pop_growth_speed = 0.5
 	}
 	potential = {
 		has_tradition = tr_genetics_finish
@@ -502,7 +502,7 @@ tech_stellarite_psi_altar = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.3
+		pop_growth_speed = 0.5
 	}
 	potential = {
 		has_tradition = tr_psionics_finish

--- a/acquistion_of_technology/common/technology/z_aot_stellarite_building_tech.txt
+++ b/acquistion_of_technology/common/technology/z_aot_stellarite_building_tech.txt
@@ -446,7 +446,7 @@ tech_stellarite_clone_vats = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.4
+		pop_growth_speed = 0.3
 	}
 	potential = {
 		has_tradition = tr_genetics_finish
@@ -502,7 +502,7 @@ tech_stellarite_psi_altar = {
 	}
 	weight = @tier5weight3
 	modifier = {
-		pop_growth_speed = 0.4
+		pop_growth_speed = 0.3
 	}
 	potential = {
 		has_tradition = tr_psionics_finish


### PR DESCRIPTION
This fixes multiple issues with pop growth and assembly I have noticed during my playthroughs:

**Issues:**
1. Phanon tech had higher pop growth boni than Stellarite tech.
2. The apothecary jobs have insane modifier jumps from alpha to phanon, a total _7.5x multiplier increase_ to pop assembly. 
3. The jump from alpha to phanon tech in terms of pop growth differs wildly between the ascensions: Psionics were completely left behind, with a pop growth modifer increase of about 2.5x. At the same time, cyborgs could increase their pop assembly alone 6x, (especially due to the ludicrous apothecary organic assembly speed multipliers) and still benefit from a 1.5x pop growth modifier. Bio ascension is somewhere in the middle, Synths enjoy an approximate 3x in pop assembly.
4. Severe performance issues after one reaches stellarite or the AI reaches Phanon tech. Stellarite again doubled or tripled all those boni from above, which allows a player to reach 5k+ pops in the endgame. This is a severe performance issue and the AI only aggravates the issue with a focus on pop growth buildings. 

**Changes:**

1. Adjusted and generally reduced the tech boni for phanon and stellarite tech to pop_growth
2. Reduced the apothecary organic pop assembly modifiers by 75% (now a 2x increase over alpha)
3. Decreased the pop assembly from the clone vats (0 for alpha (unchanged), 16->10 for phanon, 32->20 for stellarite)
4. Massively reduced the pop assembly from the robomen (10 for alpha (unchanged), 30->12.5 for phanon, 64->15.5 for stellarite). This is now only 1.25x increase for each tech level, but with the added multipliers from the apothecary, this is still a significant increase. Also, there are 2 robomen compared to only one clone vat.
5. Decreased the cyborg organic pop assembly to the same as the machine pop assembly as the apothecary multipliers improve them further.
6. This means that cyborg's pop assembly decreased by about 75%, but is still by far the most powerful one due to apothecary multipliers. Synth and machine assembly decreased by about 60%. Bio assembly decreased by about 50% and psionics were unchanged. With this, the population explosion after phanon or stellarite tech is reached is dampened a lot.