### PR TITLE
🐛 Fixed low anticrime value on DM enforcers

### DIFF
--- a/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
+++ b/acquistion_of_technology/common/pop_jobs/aot_special_jobs.txt
@@ -38,7 +38,7 @@ aot_dm_enforcer = {
 		pop_defense_armies_add = 1
 	}
 	planet_modifier = {
-		planet_crime_add = -20
+		planet_crime_add = -35
 		planet_stability_add = 2
 	}
 	triggered_planet_modifier = {
@@ -49,7 +49,7 @@ aot_dm_enforcer = {
 			}
 		}
 		modifier = {
-			planet_crime_add = -10
+			planet_crime_add = -15
 		}
 	}
 	weight = {
@@ -184,7 +184,7 @@ aot_dm_enforcer_drone = {
 		pop_defense_armies_add = 1
 	}
 	planet_modifier = {
-		planet_crime_no_happiness_add = -20
+		planet_crime_no_happiness_add = -35
 		planet_stability_add = 2
 	}
 	weight = {
@@ -3247,7 +3247,7 @@ phanon_enforcer = {
 			}
 		}
 		modifier = {
-			planet_crime_add = -20
+			planet_crime_add = -25
 		}
 	}
 	weight = {
@@ -5809,7 +5809,7 @@ stellarite_enforcer = {
 		pop_defense_armies_add = 9
 	}
 	planet_modifier = {
-		planet_crime_add = -60
+		planet_crime_add = -80
 		planet_stability_add = 15
 	}
 	triggered_planet_modifier = {
@@ -5820,7 +5820,7 @@ stellarite_enforcer = {
 			}
 		}
 		modifier = {
-			planet_crime_add = -20
+			planet_crime_add = -30
 		}
 	}
 	weight = {
@@ -5954,7 +5954,7 @@ stellarite_enforcer_drone = {
 		pop_defense_armies_add = 9
 	}
 	planet_modifier = {
-		planet_crime_no_happiness_add = -60
+		planet_crime_no_happiness_add = -80
 		planet_stability_add = 15
 	}
 	weight = {


### PR DESCRIPTION
Enforcer crime reduction used to be:
(base value / extra value with the crime reduction decision)

- vanilla = 25 / 10
- aot dm = 20 / 10 (big issue, is lower than vanilla)
- acot = 40 / 20
- phanon = 60 / 20
- stellarite = 60 / 20

Now it is:

- vanilla = 25 / 10
- aot dm = 35 / 15 (increased to be higher than vanilla, hard to find a good intermediate value between vanilla and ACOT)
- acot = 40 / 20
- phanon = 60 / 25 (increased decision reduction to scale linearly)
- stellarite = 80 / 30 (increased crime reduction to linearly scale with acot and phanon)